### PR TITLE
Support absolute paths for inputs

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -19,7 +19,7 @@ class Generator {
 
   constructor(input: string, options: Options) {
     this.packageJson = require(path.join(process.cwd(), 'package.json'));
-    this.input = path.join(process.cwd(), input);
+    this.input = path.isAbsolute(input) ? input : path.join(process.cwd(), input);
     this.dir = path.dirname(this.input);
     this.output = options.output || this.packageJson.types;
     this.extensions = options.extensions || ['.svelte', '.ts', '.js'];


### PR DESCRIPTION
Some tools, either via the CLI or through rollup, have cases where absolute input paths are supplied. In that case, use the absolute path directly, as appending it to the current working directory results in a path that does not exist.